### PR TITLE
chore: add npm package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,10 @@
     "type": "git",
     "url": "git+https://github.com/wojtekmaj/vite-plugin-simple-html.git"
   },
+  "bugs": {
+    "url": "https://github.com/wojtekmaj/vite-plugin-simple-html/issues"
+  },
+  "homepage": "https://github.com/wojtekmaj/vite-plugin-simple-html#readme",
   "funding": "https://github.com/wojtekmaj/vite-plugin-simple-html?sponsor=1",
   "packageManager": "yarn@4.14.1"
 }


### PR DESCRIPTION
## Summary
- Add npm `bugs` metadata pointing to this repository's issue tracker.
- Add npm `homepage` metadata pointing to the README.

## Verification
- `node -e "const p=require('./package.json'); console.log(JSON.stringify({bugs:p.bugs, homepage:p.homepage}, null, 2))"`
- `git diff --check`

This is a metadata-only package manifest update.
