### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,10 @@
     "type": "git",
     "url": "git+https://github.com/wojtekmaj/vite-plugin-simple-html.git"
   },
+  "homepage": "https://github.com/wojtekmaj/vite-plugin-simple-html#readme",
+  "bugs": {
+    "url": "https://github.com/wojtekmaj/vite-plugin-simple-html/issues"
+  },
   "funding": "https://github.com/wojtekmaj/vite-plugin-simple-html?sponsor=1",
   "packageManager": "yarn@4.14.1"
 }


### PR DESCRIPTION
## Summary
- add npm homepage metadata pointing to the repository README
- add bugs.url metadata pointing to the repository issue tracker

## Notes
- metadata-only change
- runtime code, dependencies, entry points, version, and package files are unchanged

## Validation
- `node -e \"const p=require('./package.json'); if (p.homepage !== 'https://github.com/wojtekmaj/vite-plugin-simple-html#readme') throw new Error('homepage mismatch'); if (p.bugs?.url !== 'https://github.com/wojtekmaj/vite-plugin-simple-html/issues') throw new Error('bugs url mismatch'); console.log('metadata ok')\"`
- `npm pack --dry-run --ignore-scripts --json`
- `corepack yarn install --immutable`
- `corepack yarn lint`
- `corepack yarn tsc`
- `corepack yarn format`
- `corepack yarn unit`
- `corepack yarn build`
- `git diff --check`