### PR TITLE
Add npm package homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,10 @@
     "type": "git",
     "url": "git+https://github.com/wojtekmaj/vite-plugin-simple-html.git"
   },
+  "homepage": "https://github.com/wojtekmaj/vite-plugin-simple-html#readme",
+  "bugs": {
+    "url": "https://github.com/wojtekmaj/vite-plugin-simple-html/issues"
+  },
   "funding": "https://github.com/wojtekmaj/vite-plugin-simple-html?sponsor=1",
   "packageManager": "yarn@4.14.1"
 }


### PR DESCRIPTION
Adds the missing `homepage` and `bugs` package metadata so the npm package links to the GitHub README and issue tracker.

Verification:
- `yarn test`